### PR TITLE
Add new option WithNoDateTime() to log. 

### DIFF
--- a/log.go
+++ b/log.go
@@ -166,6 +166,19 @@ func WithNoColor() Option {
 	}
 }
 
+func WithNoDateTime() Option {
+	return func(l *StdLog) {
+		flags := l.inf.Flags()
+		flags &= log.Ldate
+		flags &= log.Ltime
+
+		l.err.SetFlags(flags)
+		l.wrn.SetFlags(flags)
+		l.inf.SetFlags(flags)
+		l.dbg.SetFlags(flags)
+	}
+}
+
 // WithLineNum enables the printing of code line number in log output.
 func WithLineNum(format LineNumFmt) Option {
 	return func(l *StdLog) {

--- a/log_test.go
+++ b/log_test.go
@@ -68,6 +68,29 @@ func TestNewWithUTC(t *testing.T) {
 	reflectStdLog(t, got)
 }
 
+func TestNewWithNoDateTime(t *testing.T) {
+	expectedFlags := 0
+	got := New(WithNoDateTime())
+
+	if got.err.Flags() != expectedFlags {
+		t.Errorf("log.Ltime and log.Ldate flags has not been removed from logger")
+	}
+
+	if got.inf.Flags() != expectedFlags {
+		t.Errorf("log.Ltime and log.Ldate flags has not been removed from logger")
+	}
+
+	if got.dbg.Flags() != expectedFlags {
+		t.Errorf("log.Ltime and log.Ldate flags has not been removed from logger")
+	}
+
+	if got.wrn.Flags() != expectedFlags {
+		t.Errorf("log.Ltime and log.Ldate flags has not been removed from logger")
+	}
+
+	reflectStdLog(t, got)
+}
+
 func TestNewWithLevelAtPrefixEnd(t *testing.T) {
 	defaultFlags := log.Ldate | log.Ltime
 	got := New(WithLevelAtPrefixEnd())


### PR DESCRIPTION
It allows to print of log lines without the date and time.